### PR TITLE
Support non-existant SeriesDate and SeriesTime

### DIFF
--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -65,9 +65,9 @@ def add_sequence_lists_to_ds(ds: FileDataset):
 def add_study_and_series_information(ds: FileDataset, series_data):
     reference_ds = series_data[0] # All elements in series should have the same data
     ds.StudyDate = reference_ds.StudyDate
-    ds.SeriesDate = reference_ds.SeriesDate
+    ds.SeriesDate = getattr(reference_ds, 'SeriesDate', '')
     ds.StudyTime = reference_ds.StudyTime
-    ds.SeriesTime = reference_ds.SeriesTime
+    ds.SeriesTime = getattr(reference_ds, 'SeriesTime', '')
     ds.StudyDescription = getattr(reference_ds, 'StudyDescription', '')
     ds.SeriesDescription = getattr(reference_ds, 'SeriesDescription', '')
     ds.StudyInstanceUID = reference_ds.StudyInstanceUID

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-VERSION = '1.1.2'
+VERSION = '1.1.3'
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 with open('requirements.txt') as f:


### PR DESCRIPTION
Here's a very simple change to support DICOM where the SeriesDate and SeriesTime aren't set. This addresses #20.

I was also having a look at #19 and I'd be happy to incorporate a solution to that in here too. I believe a suggestion in that thread was to sort using the 3 component of ImagePositionPatient..? I can't think of any reason why this wouldn't work? Alternatively we could check if SliceLocation is available and if not fall back to the ImagePositionPatient?

Cheers
Phil
