### PR TITLE
27 roigeneration algorithm

### DIFF
--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -127,14 +127,14 @@ def create_contour_image_sequence(series_data) -> Sequence:
     return contour_image_sequence
 
 
-def create_structure_set_roi(roi_data: ROIData) -> Dataset:
+def create_structure_set_roi(roi_data: ROIData, ROIGenerationAlgorithm='AUTOMATIC') -> Dataset:
     # Structure Set ROI Sequence: Structure Set ROI 1
     structure_set_roi = Dataset()
     structure_set_roi.ROINumber = roi_data.number
     structure_set_roi.ReferencedFrameOfReferenceUID = roi_data.frame_of_reference_uid
     structure_set_roi.ROIName = roi_data.name
     structure_set_roi.ROIDescription = roi_data.description
-    structure_set_roi.ROIGenerationAlgorithm = 'MANUAL'
+    structure_set_roi.ROIGenerationAlgorithm = ROIGenerationAlgorithm
     return structure_set_roi
 
 

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -32,12 +32,14 @@ class RTStruct:
         description: str = '', 
         use_pin_hole: bool = False,
         approximate_contours: bool = True,
+        ROIGenerationAlgorithm: str = 'AUTOMATIC'
         ):
         """
         Add a ROI to the rtstruct given a 3D binary mask for the ROI's at each slice
         Optionally input a color or name for the ROI
         If use_pin_hole is set to true, will cut a pinhole through ROI's with holes in them so that they are represented with one contour
         If approximate_contours is set to False, no approximation will be done when generating contour data, leading to much larger amount of contour data
+        ROIGenerationAlgorithm reflects the creation of the mask
         """
 
         # TODO test if name already exists
@@ -55,7 +57,7 @@ class RTStruct:
             )
 
         self.ds.ROIContourSequence.append(ds_helper.create_roi_contour(roi_data, self.series_data))
-        self.ds.StructureSetROISequence.append(ds_helper.create_structure_set_roi(roi_data))
+        self.ds.StructureSetROISequence.append(ds_helper.create_structure_set_roi(roi_data, ROIGenerationAlgorithm))
         self.ds.RTROIObservationsSequence.append(ds_helper.create_rtroi_observation(roi_data))
 
     def validate_mask(self, mask: np.ndarray) -> bool:

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -39,7 +39,7 @@ class RTStruct:
         Optionally input a color or name for the ROI
         If use_pin_hole is set to true, will cut a pinhole through ROI's with holes in them so that they are represented with one contour
         If approximate_contours is set to False, no approximation will be done when generating contour data, leading to much larger amount of contour data
-        ROIGenerationAlgorithm reflects the creation of the mask
+        ROIGenerationAlgorithm contains information on how the mask was created, default 'AUTOMATIC'
         """
 
         # TODO test if name already exists


### PR DESCRIPTION
Fixes issue #27. The value of the attribute ROIGenerationAlgorithm can now be set by the optional input argument ROIGenerationAlgorithm of add_roi.
I'm not sure if the upper case argument matches the conventions of your library, would you prefer something like 'roi_generation_algorithm'?
IMO the default value should be 'AUTOMATIC' as I guess that most of the users will use the library for exporting of some segmentations created by ML algorithms. In practice I found the previous default 'MANUAL' rare, our Radiologist work with 'SEMIAUTOMATIC' algorithms.
In our lab we have three different dcm viewers and I found that one of them raises a complaint when the ROIGenerationAlgorithm is not one of 'AUTOMATIC', 'SEMIAUTOMATIC', or 'MANUAL', do you think it is worth raising a warning when a user picks a different option?
Sorry for the very long message about this very simple change.
Thanks for letting me participate in this!