### PR TITLE
35 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Intellij
+.idea/
+
 # Distribution / packaging
 bin/
 build/

--- a/rt_utils/image_helper.py
+++ b/rt_utils/image_helper.py
@@ -83,7 +83,7 @@ def find_mask_contours(mask: np.ndarray, approximate_contours: bool):
     approximation_method = cv.CHAIN_APPROX_SIMPLE if approximate_contours else cv.CHAIN_APPROX_NONE 
     contours, hierarchy = cv.findContours(mask.astype(np.uint8), cv.RETR_TREE, approximation_method)
     # Format extra array out of data
-    contours = list(contours)
+    contours = list(contours)  # Open-CV updated contours to be a tuple so we convert it back into a list here
     for i, contour in enumerate(contours):
         contours[i] = [[pos[0][0], pos[0][1]] for pos in contour]
     hierarchy = hierarchy[0] # Format extra array out of data

--- a/rt_utils/image_helper.py
+++ b/rt_utils/image_helper.py
@@ -83,6 +83,7 @@ def find_mask_contours(mask: np.ndarray, approximate_contours: bool):
     approximation_method = cv.CHAIN_APPROX_SIMPLE if approximate_contours else cv.CHAIN_APPROX_NONE 
     contours, hierarchy = cv.findContours(mask.astype(np.uint8), cv.RETR_TREE, approximation_method)
     # Format extra array out of data
+    contours = list(contours)
     for i, contour in enumerate(contours):
         contours[i] = [[pos[0][0], pos[0][1]] for pos in contour]
     hierarchy = hierarchy[0] # Format extra array out of data

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -15,7 +15,8 @@ class RTStruct:
     def __init__(self, series_data, ds: FileDataset, ROIGenerationAlgorithm=0):
         self.series_data = series_data
         self.ds = ds
-        self.frame_of_reference_uid = ds.ReferencedFrameOfReferenceSequence[-1].FrameOfReferenceUID  # Use last strucitured set ROI
+        self.frame_of_reference_uid = ds.ReferencedFrameOfReferenceSequence[
+            -1].FrameOfReferenceUID  # Use last strucitured set ROI
 
     def set_series_description(self, description: str):
         """
@@ -25,15 +26,15 @@ class RTStruct:
         self.ds.SeriesDescription = description
 
     def add_roi(
-        self,
-        mask: np.ndarray,
-        color: Union[str, List[int]] = None,
-        name: str = None,
-        description: str = '', 
-        use_pin_hole: bool = False,
-        approximate_contours: bool = True,
-        roi_generation_algorithm: Union[str, int] = 0
-        ):
+            self,
+            mask: np.ndarray,
+            color: Union[str, List[int]] = None,
+            name: str = None,
+            description: str = '',
+            use_pin_hole: bool = False,
+            approximate_contours: bool = True,
+            roi_generation_algorithm: Union[str, int] = 0,
+            use_media_storage: bool = True):
         """
         Add a ROI to the rtstruct given a 3D binary mask for the ROI's at each slice
         Optionally input a color or name for the ROI
@@ -54,9 +55,9 @@ class RTStruct:
             use_pin_hole,
             approximate_contours,
             roi_generation_algorithm
-            )
+        )
 
-        self.ds.ROIContourSequence.append(ds_helper.create_roi_contour(roi_data, self.series_data))
+        self.ds.ROIContourSequence.append(ds_helper.create_roi_contour(roi_data, self.series_data, use_media_storage))
         self.ds.StructureSetROISequence.append(ds_helper.create_structure_set_roi(roi_data))
         self.ds.RTROIObservationsSequence.append(ds_helper.create_rtroi_observation(roi_data))
 

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -34,7 +34,7 @@ class RTStruct:
             use_pin_hole: bool = False,
             approximate_contours: bool = True,
             roi_generation_algorithm: Union[str, int] = 0,
-            use_media_storage: bool = True):
+        ):
         """
         Add a ROI to the rtstruct given a 3D binary mask for the ROI's at each slice
         Optionally input a color or name for the ROI
@@ -57,7 +57,7 @@ class RTStruct:
             roi_generation_algorithm
         )
 
-        self.ds.ROIContourSequence.append(ds_helper.create_roi_contour(roi_data, self.series_data, use_media_storage))
+        self.ds.ROIContourSequence.append(ds_helper.create_roi_contour(roi_data, self.series_data))
         self.ds.StructureSetROISequence.append(ds_helper.create_structure_set_roi(roi_data))
         self.ds.RTROIObservationsSequence.append(ds_helper.create_rtroi_observation(roi_data))
 

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -23,7 +23,7 @@ class RTStructBuilder:
         return RTStruct(series_data, ds)
 
     @staticmethod
-    def create_from(dicom_series_path: str, rt_struct_path: str) -> RTStruct:
+    def create_from(dicom_series_path: str, rt_struct_path: str, use_media_storage: bool = True) -> RTStruct:
         """
         Method to load an existing rt struct, given related DICOM series and existing rt struct
         """
@@ -31,7 +31,7 @@ class RTStructBuilder:
         series_data = image_helper.load_sorted_image_series(dicom_series_path)
         ds = dcmread(rt_struct_path)
         RTStructBuilder.validate_rtstruct(ds)
-        RTStructBuilder.validate_rtstruct_series_references(ds, series_data)
+        RTStructBuilder.validate_rtstruct_series_references(ds, series_data, use_media_storage)
 
         # TODO create new frame of reference? Right now we assume the last frame of reference created is suitable 
         return RTStruct(series_data, ds)
@@ -49,7 +49,7 @@ class RTStructBuilder:
             raise Exception("Please check that the existing RTStruct is valid")
 
     @staticmethod
-    def validate_rtstruct_series_references(ds: Dataset, series_data: List[Dataset]):
+    def validate_rtstruct_series_references(ds: Dataset, series_data: List[Dataset], use_media_storage: bool = True):
         """
         Method to validate RTStruct only references dicom images found within the input series_data
         """
@@ -58,19 +58,25 @@ class RTStructBuilder:
                 for rt_refd_series in rt_refd_study.RTReferencedSeriesSequence:
                     for contour_image in rt_refd_series.ContourImageSequence:
                         RTStructBuilder.validate_contour_image_in_series_data(
-                            contour_image, series_data)
+                            contour_image, series_data, use_media_storage)
 
     @staticmethod
-    def validate_contour_image_in_series_data(contour_image: Dataset, series_data: List[Dataset]):
+    def validate_contour_image_in_series_data(contour_image: Dataset, series_data: List[Dataset],
+                                              use_media_storage: bool = True):
         """
         Method to validate that the ReferencedSOPInstanceUID of a given contour image exists within the series data
         """
-        for series in series_data:
-            if contour_image.ReferencedSOPInstanceUID == series.file_meta.MediaStorageSOPInstanceUID:
-                return
+        if use_media_storage:
+            for series in series_data:
+                if contour_image.ReferencedSOPInstanceUID == series.file_meta.MediaStorageSOPInstanceUID:
+                    return
+        else:
+            for series in series_data:
+                if contour_image.ReferencedSOPInstanceUID == series.SOPInstanceUID:
+                    return
 
         # ReferencedSOPInstanceUID is NOT available
         raise Exception(
-            f'Loaded RTStruct references image(s) that are not contained in input series data. ' + 
+            f'Loaded RTStruct references image(s) that are not contained in input series data. ' +
             f'Problematic image has SOP Instance Id: {contour_image.ReferencedSOPInstanceUID}'
         )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-VERSION = '1.1.6'
+VERSION = '1.1.7'
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 with open('requirements.txt') as f:

--- a/tests/test_rtstruct_builder.py
+++ b/tests/test_rtstruct_builder.py
@@ -5,6 +5,7 @@ from rt_utils import RTStructBuilder
 from rt_utils.utils import SOPClassUID
 from rt_utils import image_helper
 from pydicom.dataset import validate_file_meta
+from pydicom.uid import generate_uid
 import numpy as np
 
 
@@ -37,7 +38,7 @@ def test_add_non_binary_roi(new_rtstruct: RTStruct):
 
 def test_add_empty_roi(new_rtstruct: RTStruct):
     mask = get_empty_mask(new_rtstruct)
-    mask = mask[:, :, 1:] # One less slice than expected
+    mask = mask[:, :, 1:]  # One less slice than expected
     with pytest.raises(RTStruct.ROIException):
         new_rtstruct.add_roi(mask)
 
@@ -59,11 +60,32 @@ def test_add_valid_roi(new_rtstruct: RTStruct):
     COLOR = [123, 123, 232]
     mask = get_empty_mask(new_rtstruct)
     mask[50:100, 50:100, 0] = 1
-    
+
     new_rtstruct.add_roi(mask, color=COLOR, name=NAME)
 
     assert len(new_rtstruct.ds.ROIContourSequence) == 1
-    assert len(new_rtstruct.ds.ROIContourSequence[0].ContourSequence) == 1 # Only 1 slice was added to
+    assert len(new_rtstruct.ds.ROIContourSequence[0].ContourSequence) == 1  # Only 1 slice was added to
+    assert len(new_rtstruct.ds.StructureSetROISequence) == 1
+    assert len(new_rtstruct.ds.RTROIObservationsSequence) == 1
+    assert new_rtstruct.ds.ROIContourSequence[0].ROIDisplayColor == COLOR
+    assert new_rtstruct.get_roi_names() == [NAME]
+
+
+def test_add_valid_roi_without_meta_uid(new_rtstruct: RTStruct):
+    assert new_rtstruct.get_roi_names() == []
+    assert len(new_rtstruct.ds.ROIContourSequence) == 0
+    assert len(new_rtstruct.ds.StructureSetROISequence) == 0
+    assert len(new_rtstruct.ds.RTROIObservationsSequence) == 0
+
+    NAME = "Test ROI"
+    COLOR = [123, 123, 232]
+    mask = get_empty_mask(new_rtstruct)
+    mask[50:100, 50:100, 0] = 1
+
+    new_rtstruct.add_roi(mask, color=COLOR, name=NAME, use_media_storage=False)
+
+    assert len(new_rtstruct.ds.ROIContourSequence) == 1
+    assert len(new_rtstruct.ds.ROIContourSequence[0].ContourSequence) == 1  # Only 1 slice was added to
     assert len(new_rtstruct.ds.StructureSetROISequence) == 1
     assert len(new_rtstruct.ds.RTROIObservationsSequence) == 1
     assert new_rtstruct.ds.ROIContourSequence[0].ROIDisplayColor == COLOR
@@ -106,12 +128,12 @@ def test_loading_valid_rt_struct(series_path):
 
     # Test adding a new ROI
     mask = get_empty_mask(rtstruct)
-    mask[50:100,50:100,0] = 1
+    mask[50:100, 50:100, 0] = 1
     rtstruct.add_roi(mask)
 
-    assert len(rtstruct.ds.ROIContourSequence) == 2 # 1 should be added
-    assert len(rtstruct.ds.StructureSetROISequence) == 2 # 1 should be added
-    assert len(rtstruct.ds.RTROIObservationsSequence) == 2 # 1 should be added
+    assert len(rtstruct.ds.ROIContourSequence) == 2  # 1 should be added
+    assert len(rtstruct.ds.StructureSetROISequence) == 2  # 1 should be added
+    assert len(rtstruct.ds.RTROIObservationsSequence) == 2  # 1 should be added
     new_roi = rtstruct.ds.StructureSetROISequence[-1]
     assert new_roi.ROIName == 'ROI-2'
 
@@ -122,7 +144,7 @@ def test_loaded_mask_iou(new_rtstruct: RTStruct):
     mask[50:100, 50:100, 0] = 1
     mask[60:150, 40:120, 0] = 1
 
-    IOU_threshold = 1.0 # Expected accuracy
+    IOU_threshold = 1.0  # Expected accuracy
     run_mask_iou_test(new_rtstruct, mask, IOU_threshold)
 
 
@@ -132,7 +154,7 @@ def test_mask_with_holes_iou(new_rtstruct: RTStruct):
     mask[50:100, 50:100, 0] = 1
     mask[65:85, 65:85, 0] = 0
 
-    IOU_threshold = 0.95 # Expect lower accuracy since holes lose information
+    IOU_threshold = 0.95  # Expect lower accuracy since holes lose information
     run_mask_iou_test(new_rtstruct, mask, IOU_threshold)
 
 
@@ -142,16 +164,18 @@ def test_pin_hole_iou(new_rtstruct: RTStruct):
     mask[50:100, 50:100, 0] = 1
     mask[65:85, 65:85, 0] = 0
 
-    IOU_threshold = 0.95 # Expect lower accuracy holes lose information
+    IOU_threshold = 0.95  # Expect lower accuracy holes lose information
     run_mask_iou_test(new_rtstruct, mask, IOU_threshold, use_pin_hole=True)
-    
+
+
 def test_no_approximation_iou(new_rtstruct: RTStruct):
     mask = get_empty_mask(new_rtstruct)
     mask[50:100, 50:100, 0] = 1
     mask[60:150, 40:120, 0] = 1
 
-    IOU_threshold = 1.0 # Expected accuracy
+    IOU_threshold = 1.0  # Expected accuracy
     run_mask_iou_test(new_rtstruct, mask, IOU_threshold, approximate_contours=False)
+
 
 def test_contour_data_sizes(new_rtstruct: RTStruct):
     mask = get_empty_mask(new_rtstruct)
@@ -165,26 +189,30 @@ def test_contour_data_sizes(new_rtstruct: RTStruct):
     # Then using approximation leads to less data within the contour data
     assert get_data_len_by_index(new_rtstruct, 0) < get_data_len_by_index(new_rtstruct, 1)
 
+
 def test_nonstandard_image_orientation(oriented_rtstruct: RTStruct):
     mask = get_empty_mask(oriented_rtstruct)
     mask[10:70, 5:15, 1] = 1
     mask[60:70, 5:40, 1] = 1
 
-    IOU_threshold = 1.0 # Expected accuracy
+    IOU_threshold = 1.0  # Expected accuracy
     run_mask_iou_test(oriented_rtstruct, mask, IOU_threshold)
+
 
 def test_one_slice_image(one_slice_rtstruct: RTStruct):
     mask = get_empty_mask(one_slice_rtstruct)
     mask[10:70, 5:15, 0] = 1
     mask[60:70, 5:40, 0] = 1
 
-    IOU_threshold = 1.0 # Expected accuracy
+    IOU_threshold = 1.0  # Expected accuracy
     run_mask_iou_test(one_slice_rtstruct, mask, IOU_threshold)
+
 
 def get_data_len_by_index(rt_struct: RTStruct, i: int):
     return len(rt_struct.ds.ROIContourSequence[i].ContourSequence[0].ContourData)
 
-def run_mask_iou_test(rtstruct:RTStruct, mask, IOU_threshold, use_pin_hole=False, approximate_contours=True):
+
+def run_mask_iou_test(rtstruct: RTStruct, mask, IOU_threshold, use_pin_hole=False, approximate_contours=True):
     # Save and load mask
     mask_name = "test"
     rtstruct.add_roi(mask, name=mask_name, use_pin_hole=use_pin_hole, approximate_contours=approximate_contours)

--- a/tests/test_rtstruct_builder.py
+++ b/tests/test_rtstruct_builder.py
@@ -71,27 +71,6 @@ def test_add_valid_roi(new_rtstruct: RTStruct):
     assert new_rtstruct.get_roi_names() == [NAME]
 
 
-def test_add_valid_roi_without_meta_uid(new_rtstruct: RTStruct):
-    assert new_rtstruct.get_roi_names() == []
-    assert len(new_rtstruct.ds.ROIContourSequence) == 0
-    assert len(new_rtstruct.ds.StructureSetROISequence) == 0
-    assert len(new_rtstruct.ds.RTROIObservationsSequence) == 0
-
-    NAME = "Test ROI"
-    COLOR = [123, 123, 232]
-    mask = get_empty_mask(new_rtstruct)
-    mask[50:100, 50:100, 0] = 1
-
-    new_rtstruct.add_roi(mask, color=COLOR, name=NAME, use_media_storage=False)
-
-    assert len(new_rtstruct.ds.ROIContourSequence) == 1
-    assert len(new_rtstruct.ds.ROIContourSequence[0].ContourSequence) == 1  # Only 1 slice was added to
-    assert len(new_rtstruct.ds.StructureSetROISequence) == 1
-    assert len(new_rtstruct.ds.RTROIObservationsSequence) == 1
-    assert new_rtstruct.ds.ROIContourSequence[0].ROIDisplayColor == COLOR
-    assert new_rtstruct.get_roi_names() == [NAME]
-
-
 def test_get_invalid_roi_mask_by_name(new_rtstruct: RTStruct):
     assert new_rtstruct.get_roi_names() == []
     with pytest.raises(RTStruct.ROIException):

--- a/tests/test_rtstruct_builder.py
+++ b/tests/test_rtstruct_builder.py
@@ -5,7 +5,6 @@ from rt_utils import RTStructBuilder
 from rt_utils.utils import SOPClassUID
 from rt_utils import image_helper
 from pydicom.dataset import validate_file_meta
-from pydicom.uid import generate_uid
 import numpy as np
 
 


### PR DESCRIPTION
Updates to #35. The file meta header values are the same as the base values so instead of providing an option when the file meta is missing, we simply just use the base values instead. Also fixes the tuple issue introduced by an open-cv update 