### PR TITLE
Update in ds_helper to support import to Pinnacle

### DIFF
--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -98,16 +98,22 @@ def add_patient_information(ds: FileDataset, series_data):
 
 def add_refd_frame_of_ref_sequence(ds: FileDataset, series_data):
     refd_frame_of_ref = Dataset()
+    try:
+        # Updated to support import of files into the treatment planning system Pinnacle
+        FrameOfRef=series_data[0]['FrameOfReferenceUID'].value
+    except:
+        FrameOfRef = generate_uid()
     refd_frame_of_ref.FrameOfReferenceUID = (
-        generate_uid()
-    )  # TODO Find out if random generation is ok
+        FrameOfRef
+    )  
     refd_frame_of_ref.RTReferencedStudySequence = create_frame_of_ref_study_sequence(
         series_data
     )
 
     # Add to sequence
     ds.ReferencedFrameOfReferenceSequence = Sequence()
-    ds.ReferencedFrameOfReferenceSequence.append(refd_frame_of_ref)
+    ds.ReferencedFrameOfReferenceSequence.append(refd_frame_of_ref) 
+
 
 
 def create_frame_of_ref_study_sequence(series_data) -> Sequence:


### PR DESCRIPTION
I have updated the function add_refd_frame_of_ref_sequence in ds_helper to support the import of files into the treatment planning system Pinnacle. There was a note in the code that the previous version should be checked. In Pinnacle, the selection of and random UID for Frame of Reference was not accepted during the import.