### PR TITLE
Fix filling of rois when there are holes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-VERSION = "1.2.2"
+VERSION = "1.2.3"
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 with open("requirements.txt") as f:

--- a/tests/test_rtstruct_builder.py
+++ b/tests/test_rtstruct_builder.py
@@ -146,12 +146,17 @@ def test_loaded_mask_iou(new_rtstruct: RTStruct):
 
 
 def test_mask_with_holes_iou(new_rtstruct: RTStruct):
-    # Create square mask with hole
+    # Create square mask with holes
     mask = get_empty_mask(new_rtstruct)
     mask[50:100, 50:100, 0] = 1
     mask[65:85, 65:85, 0] = 0
+    # add another structure with hole inside of hole
+    mask[120:230, 120:230, 0] = 1
+    mask[135:215, 135:215, 0] = 0
+    mask[150:200, 150:200, 0] = 1
+    mask[165:185, 165:185, 0] = 0
 
-    IOU_threshold = 0.95  # Expect lower accuracy since holes lose information
+    IOU_threshold = 1
     run_mask_iou_test(new_rtstruct, mask, IOU_threshold)
 
 


### PR DESCRIPTION
First of all thanks for this great package to deal with RT structures. 

## Description of PR
As stated in the "How it works" rt-utils is not handling holes perfectly. In this PR I am trying to fix this. 
Currently, rt-utils handle multiple polygons of one slice by adding them separately and [subtracting/inverting if it is a hole ](https://github.com/qurit/rt-utils/blob/6c52b8d10934907ad36250d1e01894adbe5ec86f/rt_utils/image_helper.py#L275) this results in more subtraction then it should be (as polygon itself is included when using `cv.fillPoly`). 
Example of this effect (note original image looks more like the following image below):
With multiple ROIs (original on the left and round trip loaded on the left):
![3521cb8d-e39d-471a-8c8c-a7eba1ed7a9e](https://user-images.githubusercontent.com/44713824/172577596-bdc2a764-ea93-4033-9631-edbca12a1dee.png)
And if only one label. 
![bad](https://user-images.githubusercontent.com/44713824/172575487-0a2b3f40-d6ec-473c-8659-36e701cd39f8.png)
And a correct one (original image on the left with polygons from `findContours`, and correct reconstructed map using round trip with only openCV's functions)
![correct_figure](https://user-images.githubusercontent.com/44713824/172575269-2bc7ea91-73e3-4b13-bc4b-b59ed0df688d.png)
Passing a list/tuple to `fillPoly` solves this issue as it will fill the mask correctly so there is no need for handling each contour manually, it just needs to be in a correct format. In this PR I am doing that. 
Please, let me know if the coding style suits your coding style, or if I need to change anything else. 

## Specific Changes
- unit test expects IOU=1.0, i.e 100% accuracy (it, expectedly, failed when I made only this change` assert 0.9619047619047619 >= 1.0`)
- unit test was expanded by one more shape (lower right on the image)
![two_holes_test](https://user-images.githubusercontent.com/44713824/171664650-89df9629-80f4-430b-ad1e-c3abfd3ebc07.png)
- merge `get_slice_mask_from_slice_contour_data` and ` get_contour_fill_mask` (removing the later)
- create a list of polygons in a correct format (and geometry) and pass it to fillPoly

## Testing
Run pytest after you install this package. 
This will, among other tests, check the round trip with the new test shape and see if it is perfect (IOU==1). 
