### PR TITLE
Make ContourSequence optional

### DIFF
--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -214,6 +214,9 @@ def get_contour_sequence_by_roi_number(ds, roi_number):
 
         # Ensure same type
         if str(roi_contour.ReferencedROINumber) == str(roi_number):
-            return roi_contour.ContourSequence
+            if hasattr(roi_contour, "ContourSequence"):
+                return roi_contour.ContourSequence
+            else:
+                return Sequence()
 
     raise Exception(f"Referenced ROI number '{roi_number}' not found")


### PR DESCRIPTION
The `get_contour_sequence_by_roi_number` function now checks if `roi_contour` has the `ContourSequence` attribute. If it does, we return the sequence, i.e. `roi_contour.ContourSequence`. Otherwise, we return an empty sequence, i.e. `Sequence()`.