### PR TITLE
Fix missing import

### DIFF
--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -12,10 +12,9 @@ class RTStruct:
     Wrapper class to facilitate appending and extracting ROI's within an RTStruct
     """
 
-    def __init__(self, series_data, ds: FileDataset, ROIGenerationAlgorithm=0, warn_only: bool = False):
+    def __init__(self, series_data, ds: FileDataset, ROIGenerationAlgorithm=0):
         self.series_data = series_data
         self.ds = ds
-        self.warn_only = warn_only
         self.frame_of_reference_uid = ds.ReferencedFrameOfReferenceSequence[
             -1
         ].FrameOfReferenceUID  # Use last strucitured set ROI

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -12,9 +12,10 @@ class RTStruct:
     Wrapper class to facilitate appending and extracting ROI's within an RTStruct
     """
 
-    def __init__(self, series_data, ds: FileDataset, ROIGenerationAlgorithm=0):
+    def __init__(self, series_data, ds: FileDataset, ROIGenerationAlgorithm=0, warn_only: bool = False):
         self.series_data = series_data
         self.ds = ds
+        self.warn_only = warn_only
         self.frame_of_reference_uid = ds.ReferencedFrameOfReferenceSequence[
             -1
         ].FrameOfReferenceUID  # Use last strucitured set ROI

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -79,13 +79,9 @@ class RTStructBuilder:
                 return
 
         # ReferencedSOPInstanceUID is NOT available
+        msg = f"Loaded RTStruct references image(s) that are not contained in input series data. "
+                + f"Problematic image has SOP Instance Id: {contour_image.ReferencedSOPInstanceUID}"
         if warning_only:
-            warnings.warn(
-                f"Loaded RTStruct references image(s) that are not contained in input series data. "
-                + f"Problematic image has SOP Instance Id: {contour_image.ReferencedSOPInstanceUID}"
-            )
+            warnings.warn(msg)
         else:
-            raise Exception(
-                f"Loaded RTStruct references image(s) that are not contained in input series data. "
-                + f"Problematic image has SOP Instance Id: {contour_image.ReferencedSOPInstanceUID}"
-            )
+            raise Exception(msg)

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -13,14 +13,14 @@ class RTStructBuilder:
     """
 
     @staticmethod
-    def create_new(dicom_series_path: str) -> RTStruct:
+    def create_new(dicom_series_path: str, warn_only: bool = False) -> RTStruct:
         """
         Method to generate a new rt struct from a DICOM series
         """
 
         series_data = image_helper.load_sorted_image_series(dicom_series_path)
         ds = ds_helper.create_rtstruct_dataset(series_data)
-        return RTStruct(series_data, ds)
+        return RTStruct(series_data, ds, warn_only=warn_only)
 
     @staticmethod
     def create_from(dicom_series_path: str, rt_struct_path: str) -> RTStruct:

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -20,7 +20,7 @@ class RTStructBuilder:
 
         series_data = image_helper.load_sorted_image_series(dicom_series_path)
         ds = ds_helper.create_rtstruct_dataset(series_data)
-        return RTStruct(series_data, ds, warn_only=warn_only)
+        return RTStruct(series_data, ds)
 
     @staticmethod
     def create_from(dicom_series_path: str, rt_struct_path: str, warn_only: bool = False) -> RTStruct:

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -2,6 +2,8 @@ from typing import List
 from pydicom.dataset import Dataset
 from pydicom.filereader import dcmread
 
+import warnings
+
 from rt_utils.utils import SOPClassUID
 from . import ds_helper, image_helper
 from .rtstruct import RTStruct

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -69,7 +69,7 @@ class RTStructBuilder:
 
     @staticmethod
     def validate_contour_image_in_series_data(
-        contour_image: Dataset, series_data: List[Dataset]
+        contour_image: Dataset, series_data: List[Dataset], warning_only: bool = False
     ):
         """
         Method to validate that the ReferencedSOPInstanceUID of a given contour image exists within the series data
@@ -79,7 +79,13 @@ class RTStructBuilder:
                 return
 
         # ReferencedSOPInstanceUID is NOT available
-        raise Exception(
-            f"Loaded RTStruct references image(s) that are not contained in input series data. "
-            + f"Problematic image has SOP Instance Id: {contour_image.ReferencedSOPInstanceUID}"
-        )
+        if warning_onlyu:
+            warnings.warn(
+                f"Loaded RTStruct references image(s) that are not contained in input series data. "
+                + f"Problematic image has SOP Instance Id: {contour_image.ReferencedSOPInstanceUID}"
+            )
+        else:
+            raise Exception(
+                f"Loaded RTStruct references image(s) that are not contained in input series data. "
+                + f"Problematic image has SOP Instance Id: {contour_image.ReferencedSOPInstanceUID}"
+            )

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -79,7 +79,7 @@ class RTStructBuilder:
                 return
 
         # ReferencedSOPInstanceUID is NOT available
-        if warning_onlyu:
+        if warning_only:
             warnings.warn(
                 f"Loaded RTStruct references image(s) that are not contained in input series data. "
                 + f"Problematic image has SOP Instance Id: {contour_image.ReferencedSOPInstanceUID}"


### PR DESCRIPTION
Following #64 a missing import causes the RTstruct create_from function to crash instead of launching a warning

I corrected the missing import and ran pytest successfully