### PR TITLE
Add shorthand function to merge two pre-existing RTStruct structure sets

### DIFF
--- a/rt_utils/__init__.py
+++ b/rt_utils/__init__.py
@@ -1,2 +1,3 @@
 from .rtstruct import RTStruct
 from .rtstruct_builder import RTStructBuilder
+from .rtstruct_merger import RTStructMerger

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -64,8 +64,8 @@ class RTStructBuilder:
             rt_roi_observation_seq.ReferencedROINumber = roi_number
 
             # check for ROI name duplication
-            for ds2_name in ds2.StructureSetROISequence.ROIName:
-                if struct_set_roi_seq.ROIName == ds2_name:
+            for struct_set_roi_seq2 in ds2.StructureSetROISequence:
+                if struct_set_roi_seq.ROIName == struct_set_roi_seq2.ROIName:
                     struct_set_roi_seq += "_2"
 
             ds2.ROIContourSequence.append(roi_contour_seq)

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -39,52 +39,6 @@ class RTStructBuilder:
         return RTStruct(series_data, ds)
 
     @staticmethod
-    def merge_rtstructs(dicom_series_path: str, rt_struct_path1: str, 
-        rt_struct_path2: str, merged_struct_path: str, warn_only: bool = False):
-        """
-        Method to merge two existing RTStruct files belonging to same series data, returning them as one RTStruct
-        """
-
-        series_data = image_helper.load_sorted_image_series(dicom_series_path)
-        ds1 = dcmread(rt_struct_path1)
-        ds2 = dcmread(rt_struct_path2)
-        print(f"Checking RTStruct from {rt_struct_path1}")
-        RTStructBuilder.validate_rtstruct(ds1)
-        print(f"Checking RTStruct from {rt_struct_path2}")
-        RTStructBuilder.validate_rtstruct(ds2)
-        print(f"Checking compatibility between {rt_struct_path1} and series data {dicom_series_path}")
-        RTStructBuilder.validate_rtstruct_series_references(ds1, series_data, warn_only)
-        print(f"Checking compatibility between {rt_struct_path2} and series data {dicom_series_path}")
-        RTStructBuilder.validate_rtstruct_series_references(ds2, series_data, warn_only)
-
-        for roi_contour_seq, struct_set_roi_seq, rt_roi_observation_seq in zip(ds1.ROIContourSequence, ds1.StructureSetROISequence, ds1.RTROIObservationsSequence):
-            roi_number = len(ds2.StructureSetROISequence) + 1
-            roi_contour_seq.ReferencedROINumber = roi_number
-            struct_set_roi_seq.ROINumber = roi_number
-            rt_roi_observation_seq.ReferencedROINumber = roi_number
-
-            # check for ROI name duplication
-            for struct_set_roi_seq2 in ds2.StructureSetROISequence:
-                if struct_set_roi_seq.ROIName == struct_set_roi_seq2.ROIName:
-                    struct_set_roi_seq += "_2"
-
-            ds2.ROIContourSequence.append(roi_contour_seq)
-            ds2.StructureSetROISequence.append(struct_set_roi_seq)
-            ds2.RTROIObservationsSequence.append(rt_roi_observation_seq)
-
-        # Add .dcm if needed
-        merged_struct_path = merged_struct_path if merged_struct_path.endswith(".dcm") else merged_struct_path + ".dcm"
-
-        try:
-            file = open(merged_struct_path, "w")
-            # Opening worked, we should have a valid merged_struct_path
-            print("Writing file to", merged_struct_path)
-            ds2.save_as(merged_struct_path)
-            file.close()
-        except OSError:
-            raise Exception(f"Cannot write to file path '{merged_struct_path}'")
-
-    @staticmethod
     def validate_rtstruct(ds: Dataset):
         """
         Method to validate a dataset is a valid RTStruct containing the required fields

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -39,6 +39,52 @@ class RTStructBuilder:
         return RTStruct(series_data, ds)
 
     @staticmethod
+    def merge_rtstructs(dicom_series_path: str, rt_struct_path1: str, 
+        rt_struct_path2: str, merged_struct_path: str, warn_only: bool = False):
+        """
+        Method to merge two existing RTStruct files belonging to same series data, returning them as one RTStruct
+        """
+
+        series_data = image_helper.load_sorted_image_series(dicom_series_path)
+        ds1 = dcmread(rt_struct_path1)
+        ds2 = dcmread(rt_struct_path2)
+        print(f"Checking RTStruct from {rt_struct_path1}")
+        RTStructBuilder.validate_rtstruct(ds1)
+        print(f"Checking RTStruct from {rt_struct_path2}")
+        RTStructBuilder.validate_rtstruct(ds2)
+        print(f"Checking compatibility between {rt_struct_path1} and series data {dicom_series_path}")
+        RTStructBuilder.validate_rtstruct_series_references(ds1, series_data, warn_only)
+        print(f"Checking compatibility between {rt_struct_path2} and series data {dicom_series_path}")
+        RTStructBuilder.validate_rtstruct_series_references(ds2, series_data, warn_only)
+
+        for roi_contour_seq, struct_set_roi_seq, rt_roi_observation_seq in zip(ds1.ROIContourSequence, ds1.StructureSetROISequence, ds1.RTROIObservationsSequence):
+            roi_number = len(ds2.StructureSetROISequence) + 1
+            roi_contour_seq.ReferencedROINumber = roi_number
+            struct_set_roi_seq.ROINumber = roi_number
+            rt_roi_observation_seq.ReferencedROINumber = roi_number
+
+            # check for ROI name duplication
+            for ds2_name in ds2.StructureSetROISequence.ROIName:
+                if struct_set_roi_seq.ROIName == ds2_name:
+                    struct_set_roi_seq += "_2"
+
+            ds2.ROIContourSequence.append(roi_contour_seq)
+            ds2.StructureSetROISequence.append(struct_set_roi_seq)
+            ds2.RTROIObservationsSequence.append(rt_roi_observation_seq)
+
+        # Add .dcm if needed
+        merged_struct_path = merged_struct_path if merged_struct_path.endswith(".dcm") else merged_struct_path + ".dcm"
+
+        try:
+            file = open(merged_struct_path, "w")
+            # Opening worked, we should have a valid merged_struct_path
+            print("Writing file to", merged_struct_path)
+            ds2.save_as(merged_struct_path)
+            file.close()
+        except OSError:
+            raise Exception(f"Cannot write to file path '{merged_struct_path}'")
+
+    @staticmethod
     def validate_rtstruct(ds: Dataset):
         """
         Method to validate a dataset is a valid RTStruct containing the required fields

--- a/rt_utils/rtstruct_merger.py
+++ b/rt_utils/rtstruct_merger.py
@@ -1,0 +1,33 @@
+from .rtstruct import RTStruct
+from .rtstruct_builder import RTStructBuilder
+from . import ds_helper, image_helper
+
+class RTStructMerger:
+
+
+    @staticmethod
+    def merge_rtstructs(dicom_series_path: str, rt_struct_path1: str, 
+        rt_struct_path2: str) -> RTStruct:
+        """
+        Method to merge two existing RTStruct files belonging to same series data, returning them as one RTStruct
+        """
+
+        rtstruct1 = RTStructBuilder.create_from(dicom_series_path, rt_struct_path1)
+        rtstruct2 = RTStructBuilder.create_from(dicom_series_path, rt_struct_path2)
+        
+        for roi_contour_seq, struct_set_roi_seq, rt_roi_observation_seq in zip(rtstruct1.ds.ROIContourSequence, rtstruct1.ds.StructureSetROISequence, rtstruct1.ds.RTROIObservationsSequence):
+            roi_number = len(rtstruct2.ds.StructureSetROISequence) + 1
+            roi_contour_seq.ReferencedROINumber = roi_number
+            struct_set_roi_seq.ROINumber = roi_number
+            rt_roi_observation_seq.ReferencedROINumber = roi_number
+
+            # check for ROI name duplication
+            for struct_set_roi_seq2 in rtstruct2.ds.StructureSetROISequence:
+                if struct_set_roi_seq.ROIName == struct_set_roi_seq2.ROIName:
+                    struct_set_roi_seq += "_2"
+
+            rtstruct2.ds.ROIContourSequence.append(roi_contour_seq)
+            rtstruct2.ds.StructureSetROISequence.append(struct_set_roi_seq)
+            rtstruct2.ds.RTROIObservationsSequence.append(rt_roi_observation_seq)
+
+        return rtstruct2


### PR DESCRIPTION
- Merge two structure sets belonging to same image series to one resulting structure set 
- Check DICOM metadata for compatibility with one another and with image series 
- Append `ROIContourSequence`, `StructureSetROISequence` and `RTROIObservationsSequence` of first dataset to array of second dataset and save merged dataset as new RTStruct file afterwards 
- Edit ROI reference number to avoid ambiguity, check datasets for name duplication