### PR TITLE
ROI_number attribution

### DIFF
--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -35,6 +35,8 @@ class RTStruct:
          while j in ROI_number :
                 j = j+1
          return j             
+    
+    """choose a ROI number which has not been attributed to the ROI already existing the original RTstructure. This might prevent duplicate and error in opening"""
 
     def add_roi(
         self,

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -41,7 +41,6 @@ class RTStruct:
         mask: np.ndarray,
         color: Union[str, List[int]] = None,
         name: str = None,
-        roi_number : int = None,
         description: str = "",
         use_pin_hole: bool = False,
         approximate_contours: bool = True,
@@ -60,7 +59,7 @@ class RTStruct:
         roi_data = ROIData(
             mask,
             color,      
-            roi_number = roi_number(self)                                       
+            roi_number = roi_number(self),                                       
             name,
             self.frame_of_reference_uid,
             description,

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -56,10 +56,12 @@ class RTStruct:
         # TODO test if name already exists
         self.validate_mask(mask)
         
+        roi_number = roi_number(self)
+        
         roi_data = ROIData(
             mask,
             color,      
-            roi_number = roi_number(self),                                       
+            roi_number,                                    
             name,
             self.frame_of_reference_uid,
             description,

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -25,12 +25,23 @@ class RTStruct:
         """
 
         self.ds.SeriesDescription = description
+        
+    def roi_number(
+         ROI_list = self.ds.StructureSetROISequence
+            for i in range(len(ROI_list)):
+                ROI_number.append(ROI_list[i].ROINumber.numerator)
+            j = 0 
+            while j in ROI_number :
+                j = j+1
+        
+        
 
     def add_roi(
         self,
         mask: np.ndarray,
         color: Union[str, List[int]] = None,
         name: str = None,
+        roi_number : int = None,
         description: str = "",
         use_pin_hole: bool = False,
         approximate_contours: bool = True,
@@ -45,11 +56,11 @@ class RTStruct:
 
         # TODO test if name already exists
         self.validate_mask(mask)
-        roi_number = len(self.ds.StructureSetROISequence) + 1
+        
         roi_data = ROIData(
             mask,
-            color,
-            roi_number,
+            color,      
+            roi_number = roi_number(0)                                       
             name,
             self.frame_of_reference_uid,
             description,

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -26,8 +26,7 @@ class RTStruct:
 
         self.ds.SeriesDescription = description
         
-    def roi_number(self):
-        
+    def roi_number(self):        
          ROI_list = self.ds.StructureSetROISequence
          ROI_number = []
          for i in range(len(ROI_list)):
@@ -56,7 +55,7 @@ class RTStruct:
 
         # TODO test if name already exists
         self.validate_mask(mask)        
-        roi_number = self.roi_number(self)        
+        roi_number = self.roi_number()        
         roi_data = ROIData(
             mask,
             color,      

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -29,6 +29,7 @@ class RTStruct:
     def roi_number(self):
         
          ROI_list = self.ds.StructureSetROISequence
+         ROI_number = []
          for i in range(len(ROI_list)):
                 ROI_number.append(ROI_list[i].ROINumber.numerator)
          j = 0 
@@ -54,10 +55,8 @@ class RTStruct:
         """
 
         # TODO test if name already exists
-        self.validate_mask(mask)
-        
-        roi_number = roi_number(self)
-        
+        self.validate_mask(mask)        
+        roi_number = self.roi_number(self)        
         roi_data = ROIData(
             mask,
             color,      

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -26,15 +26,15 @@ class RTStruct:
 
         self.ds.SeriesDescription = description
         
-    def roi_number(
+    def roi_number(self):
+        
          ROI_list = self.ds.StructureSetROISequence
-            for i in range(len(ROI_list)):
+         for i in range(len(ROI_list)):
                 ROI_number.append(ROI_list[i].ROINumber.numerator)
-            j = 0 
-            while j in ROI_number :
+         j = 0 
+         while j in ROI_number :
                 j = j+1
-        
-        
+         return j             
 
     def add_roi(
         self,
@@ -60,7 +60,7 @@ class RTStruct:
         roi_data = ROIData(
             mask,
             color,      
-            roi_number = roi_number(0)                                       
+            roi_number = roi_number(self)                                       
             name,
             self.frame_of_reference_uid,
             description,


### PR DESCRIPTION
When trying to automatize  addition of ROI in several RTstructure files, one problem is that ROI number in RTstructure might differ and are not successive (sometime going from 10 to 50). 
Here is a proposition to check if the ROI number exists and give an original ROI number to prevent error in opening of the RT 
structure in software.