### PR TITLE
Support adding ROIs from polygon data

### DIFF
--- a/rt_utils/image_helper.py
+++ b/rt_utils/image_helper.py
@@ -48,19 +48,25 @@ def get_contours_coords(roi_data: ROIData, series_data):
 
     series_contours = []
     for i, series_slice in enumerate(series_data):
-        mask_slice = roi_data.mask[:, :, i]
+        if roi_data.polygon is None:
+            mask_slice = roi_data.mask[:, :, i]
 
-        # Do not add ROI's for blank slices
-        if np.sum(mask_slice) == 0:
-            series_contours.append([])
-            continue
+            # Do not add ROI's for blank slices
+            if np.sum(mask_slice) == 0:
+                series_contours.append([])
+                continue
 
-        # Create pin hole mask if specified
-        if roi_data.use_pin_hole:
-            mask_slice = create_pin_hole_mask(mask_slice, roi_data.approximate_contours)
+            # Create pin hole mask if specified
+            if roi_data.use_pin_hole:
+                mask_slice = create_pin_hole_mask(mask_slice, roi_data.approximate_contours)
 
-        # Get contours from mask
-        contours, _ = find_mask_contours(mask_slice, roi_data.approximate_contours)
+            # Get contours from mask
+            contours, _ = find_mask_contours(mask_slice, roi_data.approximate_contours)
+        else:
+            if sum([p.area for p in roi_data.polygon[i]]) == 0:
+                continue
+            contours = [p.coords.tolist() for p in roi_data.polygon[i]]
+
         validate_contours(contours)
 
         # Format for DICOM

--- a/rt_utils/utils.py
+++ b/rt_utils/utils.py
@@ -2,6 +2,8 @@ from typing import List, Union
 from random import randrange
 from pydicom.uid import PYDICOM_IMPLEMENTATION_UID
 from dataclasses import dataclass
+import numpy as np
+from PIL import Image, ImageDraw
 
 COLOR_PALETTE = [
     [255, 0, 255],
@@ -41,16 +43,40 @@ class SOPClassUID:
 @dataclass
 class ROIData:
     """Data class to easily pass ROI data to helper methods."""
+    def __init__(self,
+                data,
+                color:str,
+                number:int,
+                name: str,
+                frame_of_reference_uid:int,
+                description:str,
+                use_pin_hole:bool=False,
+                approximate_contours:bool=True,
+                roi_generation_algorithm: Union[str, int] = 0) -> None:
+        """
+        The ROI data can be in two formats.
+            1, a [H, W, N] tensor contain N binary masks where N ths number of slices.
+            2, a list of contour coordinates representing the vertex of a polygon ROI
+        """
+        assert isinstance(data, (np.ndarray, list))
+        if isinstance(data, np.ndarray):
+            self.mask = data
+            self.polygon = None
+        else:
+            self.polygon = self.valaidate_polygon(data)
+            self.mask=self.polygon2mask(data)
+            self.polygon = data
+        # set attributes
+        self.color = color
+        self.number = number
+        self.name = name
+        self.frame_of_reference_uid = frame_of_reference_uid
+        self.description = description
+        self.use_pin_hole = use_pin_hole
+        self.approximate_contours = approximate_contours
+        self.roi_generation_algorithm = roi_generation_algorithm
 
-    mask: str
-    color: Union[str, List[int]]
-    number: int
-    name: str
-    frame_of_reference_uid: int
-    description: str = ""
-    use_pin_hole: bool = False
-    approximate_contours: bool = True
-    roi_generation_algorithm: Union[str, int] = 0
+        self.__post_init__()
 
     def __post_init__(self):
         self.validate_color()
@@ -125,3 +151,68 @@ class ROIData:
                     type(self.roi_generation_algorithm)
                 )
             )
+
+    def valaidate_polygon(self, polygon):
+        all_poly = [item for sublist in polygon for item in sublist]
+        if len(all_poly) == 0:
+            raise ValueError('Empty polygon')
+        else:
+            h, w = all_poly[0].h, all_poly[0].w
+        # fill empty list with a placeholder Polygon2D
+        for idx, poly in enumerate(polygon):
+            if len(poly) == 0:
+                polygon[idx] = Polygon2D(coords=[], h=h, w=w)
+        return polygon
+
+    @staticmethod
+    def polygon2mask(polygon):
+        all_poly = [item for sublist in polygon for item in sublist]
+        h, w = all_poly[0].h, all_poly[0].w
+        mask = np.zeros((h, w, len(polygon)), dtype=bool)
+        for idx, poly in enumerate(polygon):
+            mask[:, :, idx] = np.concatenate([p.mask[:, :, None] for p in poly], axis=2).sum(axis=2).astype(bool)
+        return mask
+
+
+class Polygon2D:
+    def __init__(self, coords, h, w) -> None:
+        """
+        coords: coordinates of vertice of a polygon [x1, y1, x2, y2, ..., xn, yn]
+        """
+        assert len(coords) % 2 == 0, 'invalid size of coords'
+        self._coords = np.array(coords).reshape(-1, 2)
+        self._h, self._w = h, w
+        self._mask = None
+        self._area = -1
+
+    @property
+    def h(self):
+        return self._h
+
+    @property
+    def w(self):
+        return self._w
+
+    @property
+    def coords(self):
+        return self._coords
+
+    @property
+    def area(self):
+        if self._area > 0:
+            return self._area
+        else:
+            return self.mask.sum()
+
+    @property
+    def mask(self):
+        if self._mask is not None:
+            return self._mask
+        else:
+            if self.coords.shape[0] <= 1:
+                self._mask = np.zeros((self.h, self.w), dtype=bool)
+            else:
+                img = Image.new('L', (self.w, self.h), 0)
+                ImageDraw.Draw(img).polygon(self.coords.flatten().tolist(), outline=1, fill=1)
+                self._mask = np.array(img, dtype=bool)
+            return self._mask


### PR DESCRIPTION
I've implemented the functionality of adding ROIs from polygons (mentioned in #77  ). I tried to keep the modifications as less as possible and keep it backward-compatitable.


* added a `Polygon2D` class to handle polygon data
* Changed ROIData __init__ function to accepts polygon data
* update the logic in `RTStruct.add_roi` to selectively construct ROI from mask or polygon
* add `validate_polygon` for `RTStruct`

## Potential bugs on existing codes:
Since I changed the __init__ function of `ROIData`, existing code with positional args may cause errors.