### PR TITLE
Round contour.ContourData to 10 decimal places

### DIFF
--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -192,6 +192,8 @@ def create_contour(series_slice: Dataset, contour_data: np.ndarray) -> Dataset:
     contour.NumberOfContourPoints = (
         len(contour_data) / 3
     )  # Each point has an x, y, and z value
+
+    # Rounds contourData to 10 decimal places to ensure it is <16 bytes length, as per NEMA DICOM standard guidelines.
     contour.ContourData = [round(val, 10) for val in contour_data]
 
     return contour

--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -192,7 +192,7 @@ def create_contour(series_slice: Dataset, contour_data: np.ndarray) -> Dataset:
     contour.NumberOfContourPoints = (
         len(contour_data) / 3
     )  # Each point has an x, y, and z value
-    contour.ContourData = contour_data
+    contour.ContourData = [round(val, 10) for val in contour_data]
 
     return contour
 

--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -193,7 +193,7 @@ def create_contour(series_slice: Dataset, contour_data: np.ndarray) -> Dataset:
         len(contour_data) / 3
     )  # Each point has an x, y, and z value
 
-    # Rounds contourData to 10 decimal places to ensure it is <16 bytes length, as per NEMA DICOM standard guidelines.
+    # Rounds ContourData to 10 decimal places to ensure it is <16 bytes length, as per NEMA DICOM standard guidelines.
     contour.ContourData = [round(val, 10) for val in contour_data]
 
     return contour


### PR DESCRIPTION
See issue #80 for fuller explanation.

This PR rounds `contour.ContourData` to 10 decimal places to ensure it is <16 bytes length, as per NEMA DICOM standard guidelines.