### PR TITLE
Add constrain on opencv version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ The format for the ROI mask is an nd numpy array of type bool. It is an array of
 pip install rt_utils
 ```
 
+## Installation in editable mode
+**Please note**: in order to install `rt_utils` in editable mode successfully, you need to have python>=3.7.
+```
+git clone https://github.com/qurit/rt-utils.git
+cd rt-utils
+pip install -e .
+```
+
 ## Creating new RT Structs
 ```Python
 from rt_utils import RTStructBuilder

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ pip install rt_utils
 ```
 
 ## Installation in editable mode
-**Please note**: in order to install `rt_utils` in editable mode successfully, you need to have python>=3.7.
 ```
 git clone https://github.com/qurit/rt-utils.git
 cd rt-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pydicom
 numpy
-opencv-python
+opencv-python>=4.0.0
 dataclasses

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -41,6 +40,6 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=required,
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Typing :: Typed",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR addresses the issue #45. Additionally, it covers:

* Description of a set of basic instructions to install the package in editable mode.
* Remove support/reference to Python3.6, as it already reached end-of-life and newer versions of `open-cv` struggle to compile. Furthermore, merge check for python 3.6 build freezes.