### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pydicom
 numpy
 opencv-python>=4.0.0
-dataclasses
+dataclasses ; python_version <= "3.6"


### PR DESCRIPTION
The pypi package dataclasses is designed as [a backport for python 3.6](https://pypi.org/project/dataclasses/). For python versions after that, it is included in python itself. Thus, it isn't necessary for later python versions, and for windows 10 for example, this [additional installation can confuse python](https://stackoverflow.com/questions/71991891/pip-gives-an-attributeerror-module-typing-has-no-attribute-classvar). I'm currently experiencing an error related to that. 
If we tweak requirements.txt to only install dataclasses for python 3.6 or lower, that issue for windows users goes away, and we have one less dependency, which is nice.