### PR TITLE
Fixed corrupt data bug for sequence creation that created a warning in our treatment planning software

### DIFF
--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -168,9 +168,11 @@ def create_contour_sequence(roi_data: ROIData, series_data) -> Sequence:
     contours_coords = get_contours_coords(roi_data, series_data)
 
     for series_slice, slice_contours in zip(series_data, contours_coords):
+
         for contour_data in slice_contours:
             contour = create_contour(series_slice, contour_data)
-            contour_sequence.append(contour)
+            if contour.ContourGeometricType == 'CLOSED_PLANAR' and contour.NumberOfContourPoints > 2:
+                contour_sequence.append(contour)
 
     return contour_sequence
 
@@ -192,9 +194,7 @@ def create_contour(series_slice: Dataset, contour_data: np.ndarray) -> Dataset:
     contour.NumberOfContourPoints = (
         len(contour_data) / 3
     )  # Each point has an x, y, and z value
-
-    # Rounds ContourData to 10 decimal places to ensure it is <16 bytes length, as per NEMA DICOM standard guidelines.
-    contour.ContourData = [round(val, 10) for val in contour_data]
+    contour.ContourData = contour_data
 
     return contour
 
@@ -216,9 +216,6 @@ def get_contour_sequence_by_roi_number(ds, roi_number):
 
         # Ensure same type
         if str(roi_contour.ReferencedROINumber) == str(roi_number):
-            if hasattr(roi_contour, "ContourSequence"):
-                return roi_contour.ContourSequence
-            else:
-                return Sequence()
+            return roi_contour.ContourSequence
 
     raise Exception(f"Referenced ROI number '{roi_number}' not found")


### PR DESCRIPTION
We observed a warning message shown after loading an RTStruct in one of our treatment planning software.
This warning can be seen in the following screenshot 

![billede](https://github.com/qurit/rt-utils/assets/18293577/e0d03e37-1de8-4665-8493-fc56f1ba7fa5)

We were able to fix this by giving the condition that a CLOSED_PLANAR contour type needs to contain at least 2 data points in order to be added to the contour sequence (this was not always the case and we saw cases where the number of contour points only contained one data point.

We are also aware that the Contour Geometric Type is currently hardcoded in the `create_contour` method. 
To future-proof our bug fix we added the `or` condition which would theoretically allow for adding a POINT contour type in the conversion without issues arising from our change.