### PR TITLE
Add ROI from coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ rtstruct.add_roi(
   name="RT-Utils ROI!"
 )
 
+# Add another ROI from coordinates
+rtstruct.add_roi_from_coordinates(
+    coordinates=[
+        [
+            # Example of One contour on one slice
+            [-20.0, -170.0, -559.0],
+            [30.0, -170.0, -559.0],
+            [30.0, -110.0, -559.0],
+            [-20.0, -110.0, -559.0],
+        ],
+        [
+            [-20.0, -170.0, -562.4],
+            [30.0, -170.0, -562.4],
+            [30.0, -110.0, -562.4],
+            [-20.0, -110.0, -562.4],
+        ]
+    ]
+)
+
 rtstruct.save('new-rt-struct')
 ```
 

--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -9,7 +9,7 @@ from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
 from pydicom.sequence import Sequence
 from pydicom.uid import ImplicitVRLittleEndian
 
-from utils import _flatten_lists
+from rt_utils.utils import _flatten_lists
 
 """
 File contains helper methods that handles DICOM header creation/formatting

--- a/rt_utils/ds_helper.py
+++ b/rt_utils/ds_helper.py
@@ -98,7 +98,7 @@ def add_patient_information(ds: FileDataset, series_data):
 
 def add_refd_frame_of_ref_sequence(ds: FileDataset, series_data):
     refd_frame_of_ref = Dataset()
-    refd_frame_of_ref.FrameOfReferenceUID =  getattr(series_data[0], 'FrameOfReferenceUID', generate_uid())
+    refd_frame_of_ref.FrameOfReferenceUID = getattr(series_data[0], 'FrameOfReferenceUID', generate_uid())
     refd_frame_of_ref.RTReferencedStudySequence = create_frame_of_ref_study_sequence(series_data)
 
     # Add to sequence

--- a/rt_utils/image_helper.py
+++ b/rt_utils/image_helper.py
@@ -8,7 +8,7 @@ from pydicom import dcmread
 from pydicom.dataset import Dataset
 from pydicom.sequence import Sequence
 
-from rt_utils.utils import ROIData, SOPClassUID
+from rt_utils.utils import ROIData
 
 
 def load_sorted_image_series(dicom_series_path: str | List[Dataset]) -> List[Dataset]:

--- a/rt_utils/image_helper.py
+++ b/rt_utils/image_helper.py
@@ -11,12 +11,14 @@ from pydicom.sequence import Sequence
 from rt_utils.utils import ROIData, SOPClassUID
 
 
-def load_sorted_image_series(dicom_series_path: str):
+def load_sorted_image_series(dicom_series_path: str | List[Dataset]) -> List[Dataset]:
     """
     File contains helper methods for loading / formatting DICOM images and contours
     """
-
-    series_data = load_dcm_images_from_path(dicom_series_path)
+    if isinstance(dicom_series_path, str):
+        series_data = load_dcm_images_from_path(dicom_series_path)
+    else:
+        series_data = dicom_series_path
 
     if len(series_data) == 0:
         raise Exception("No DICOM Images found in input path")

--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -68,6 +68,39 @@ class RTStruct:
             ds_helper.create_rtroi_observation(roi_data)
         )
 
+    def add_roi_from_coordinates(
+            self,
+            coordinates: List[List[List[float]]],
+            color: Union[str, List[int]] = None,
+            name: str = None,
+            description: str = "",
+            use_pin_hole: bool = False,
+            approximate_contours: bool = True,
+            roi_generation_algorithm: Union[str, int] = 0,
+    ):
+        roi_number = len(self.ds.StructureSetROISequence) + 1
+        roi_data = ROIData(
+            np.zeros(1),  # Fake mask since we do not use it because we use coordinates
+            color,
+            roi_number,
+            name,
+            self.frame_of_reference_uid,
+            description,
+            use_pin_hole,
+            approximate_contours,
+            roi_generation_algorithm,
+        )
+
+        self.ds.ROIContourSequence.append(
+            ds_helper.create_roi_contour_from_coordinates(coordinates, roi_data, self.series_data)
+        )
+        self.ds.StructureSetROISequence.append(
+            ds_helper.create_structure_set_roi(roi_data)
+        )
+        self.ds.RTROIObservationsSequence.append(
+            ds_helper.create_rtroi_observation(roi_data)
+        )
+
     def validate_mask(self, mask: np.ndarray) -> bool:
         if mask.dtype != bool:
             raise RTStruct.ROIException(

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -15,7 +15,7 @@ class RTStructBuilder:
     """
 
     @staticmethod
-    def create_new(dicom_series_path: str) -> RTStruct:
+    def create_new(dicom_series_path: str | List[Dataset]) -> RTStruct:
         """
         Method to generate a new rt struct from a DICOM series
         """
@@ -25,7 +25,7 @@ class RTStructBuilder:
         return RTStruct(series_data, ds)
 
     @staticmethod
-    def create_from(dicom_series_path: str, rt_struct_path: str, warn_only: bool = False) -> RTStruct:
+    def create_from(dicom_series_path: str | List[Dataset], rt_struct_path: str, warn_only: bool = False) -> RTStruct:
         """
         Method to load an existing rt struct, given related DICOM series and existing rt struct
         """

--- a/rt_utils/utils.py
+++ b/rt_utils/utils.py
@@ -1,5 +1,4 @@
 from typing import List, Union
-from random import randrange
 
 import numpy as np
 from pydicom.uid import PYDICOM_IMPLEMENTATION_UID
@@ -126,3 +125,12 @@ class ROIData:
                     type(self.roi_generation_algorithm)
                 )
             )
+
+
+def _flatten_lists(lists: List[List[float]]) -> List[float]:
+    """Flatten the list [[1, 2, 3], [1, 2, 3] -> [1, 2, 3, 1, 2, 3]"""
+    flatten_list = []
+    for l in lists:
+        flatten_list += l
+
+    return flatten_list

--- a/rt_utils/utils.py
+++ b/rt_utils/utils.py
@@ -1,5 +1,7 @@
 from typing import List, Union
 from random import randrange
+
+import numpy as np
 from pydicom.uid import PYDICOM_IMPLEMENTATION_UID
 from dataclasses import dataclass
 
@@ -41,8 +43,7 @@ class SOPClassUID:
 @dataclass
 class ROIData:
     """Data class to easily pass ROI data to helper methods."""
-
-    mask: str
+    mask: np.ndarray
     color: Union[str, List[int]]
     number: int
     name: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
-from rt_utils.rtstruct import RTStruct
-import pytest
 import os
-from rt_utils import RTStructBuilder
+from typing import List
+
+import pydicom
+import pytest
+
+from rt_utils import RTStructBuilder, image_helper
+from rt_utils.rtstruct import RTStruct
 
 
 @pytest.fixture()
@@ -10,12 +14,22 @@ def series_path() -> str:
 
 
 @pytest.fixture()
+def series_datasets(series_path) -> List[pydicom.Dataset]:
+    return image_helper.load_dcm_images_from_path(series_path)
+
+
+@pytest.fixture()
+def rtstruct_path(series_path) -> str:
+    return os.path.join(series_path, "rt.dcm")
+
+
+@pytest.fixture()
 def new_rtstruct() -> RTStruct:
     return get_rtstruct("mock_data")
 
 
 @pytest.fixture()
-def oriented_series_path() -> RTStruct:
+def oriented_series_path() -> str:
     return get_and_test_series_path("oriented_data")
 
 
@@ -25,7 +39,7 @@ def oriented_rtstruct() -> RTStruct:
 
 
 @pytest.fixture()
-def one_slice_series_path() -> RTStruct:
+def one_slice_series_path() -> str:
     return get_and_test_series_path("one_slice_data")
 
 

--- a/tests/test_rtstruct_builder.py
+++ b/tests/test_rtstruct_builder.py
@@ -1,9 +1,9 @@
+from _pytest.fixtures import FixtureRequest
+
 from rt_utils.rtstruct import RTStruct
 import pytest
 import os
 from rt_utils import RTStructBuilder
-from rt_utils.utils import SOPClassUID
-from rt_utils import image_helper
 from pydicom.dataset import validate_file_meta
 import numpy as np
 
@@ -13,6 +13,13 @@ def test_create_from_empty_series_dir():
     assert os.path.exists(empty_dir_path)
     with pytest.raises(Exception):
         RTStructBuilder.create_new(empty_dir_path)
+
+
+@pytest.mark.parametrize('series_fixture', ['series_path', 'series_datasets'])
+def test_create_new_datasets(series_fixture, request: FixtureRequest):
+    rtstruct = RTStructBuilder.create_new(request.getfixturevalue(series_fixture))
+
+    assert len(rtstruct.ds.ReferencedFrameOfReferenceSequence[0].RTReferencedStudySequence) != 0
 
 
 def test_only_images_loaded_into_series_data(new_rtstruct: RTStruct):
@@ -112,10 +119,10 @@ def test_non_existant_referenced_study_sequence(series_path):
     )
 
 
-def test_loading_valid_rt_struct(series_path):
-    valid_rt_struct_path = os.path.join(series_path, "rt.dcm")
-    assert os.path.exists(valid_rt_struct_path)
-    rtstruct = RTStructBuilder.create_from(series_path, valid_rt_struct_path)
+@pytest.mark.parametrize('series_fixture', ['series_path', 'series_datasets'])
+def test_loading_valid_rt_struct(rtstruct_path, series_fixture, request: FixtureRequest):
+    assert os.path.exists(rtstruct_path)
+    rtstruct = RTStructBuilder.create_from(request.getfixturevalue(series_fixture), rtstruct_path)
 
     # Tests existing values predefined in the file are found
     assert hasattr(rtstruct.ds, "ROIContourSequence")

--- a/tests/test_rtstruct_builder.py
+++ b/tests/test_rtstruct_builder.py
@@ -81,6 +81,41 @@ def test_add_valid_roi(new_rtstruct: RTStruct):
     assert new_rtstruct.get_roi_names() == [NAME]
 
 
+def test_add_valid_roi_from_coordinates(new_rtstruct: RTStruct):
+    assert new_rtstruct.get_roi_names() == []
+    assert len(new_rtstruct.ds.ROIContourSequence) == 0
+    assert len(new_rtstruct.ds.StructureSetROISequence) == 0
+    assert len(new_rtstruct.ds.RTROIObservationsSequence) == 0
+
+    NAME = "Test ROI"
+    COLOR = [123, 123, 232]
+    coordinates = [
+        [
+            [-100, -100, 60],
+            [-100, -75, 60],
+            [-75, -75, 60],
+            [-75, -100, 60]
+        ],
+        [
+            [-90, -90, 65],
+            [-90, -65, 65],
+            [-65, -65, 65],
+            [-65, -90, 65],
+        ]
+    ]
+
+    new_rtstruct.add_roi_from_coordinates(coordinates, color=COLOR, name=NAME)
+
+    assert len(new_rtstruct.ds.ROIContourSequence) == 1
+    assert (
+            len(new_rtstruct.ds.ROIContourSequence[0].ContourSequence) == 2
+    )  # 2 contour on to slice were added
+    assert len(new_rtstruct.ds.StructureSetROISequence) == 1
+    assert len(new_rtstruct.ds.RTROIObservationsSequence) == 1
+    assert new_rtstruct.ds.ROIContourSequence[0].ROIDisplayColor == COLOR
+    assert new_rtstruct.get_roi_names() == [NAME]
+
+
 def test_get_invalid_roi_mask_by_name(new_rtstruct: RTStruct):
     assert new_rtstruct.get_roi_names() == []
     with pytest.raises(RTStruct.ROIException):


### PR DESCRIPTION
This PR adds a new method, `RTStruct.add_from_coordinates()` where users can add a polygon from coordinates of `x, y, z` values.

This is how it looks for the user
```python
rtstruct.add_roi_from_coordinates(
    coordinates=[
        [
            # Example of a contour
            [-20.0, -170.0, -559.0],
            [30.0, -170.0, -559.0],
            [30.0, -110.0, -559.0],
            [-20.0, -110.0, -559.0],
        ],
        [
            [-20.0, -170.0, -562.4],
            [30.0, -170.0, -562.4],
            [30.0, -110.0, -562.4],
            [-20.0, -110.0, -562.4],
        ]
    ]
)
```