### PR TITLE
Enhancement for API use

### DIFF
--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -1,9 +1,12 @@
+from io import BytesIO
 from typing import List, Union
 
 import numpy as np
+import pydicom
 from pydicom.dataset import FileDataset
 
 from rt_utils.utils import ROIData
+
 from . import ds_helper, image_helper
 
 
@@ -133,6 +136,15 @@ class RTStruct:
             file.close()
         except OSError:
             raise Exception(f"Cannot write to file path '{file_path}'")
+        
+    def save_to_memory(self):
+        """
+        Saves the RTStruct to a BytesIO stream and returns it.
+        """
+        buffer = BytesIO()
+        pydicom.dcmwrite(buffer, self.ds)
+        buffer.seek(0)  # Rewind the buffer for reading
+        return buffer
 
     class ROIException(Exception):
         """

--- a/rt_utils/rtstruct_builder.py
+++ b/rt_utils/rtstruct_builder.py
@@ -1,10 +1,11 @@
+import warnings
 from typing import List
+
 from pydicom.dataset import Dataset
 from pydicom.filereader import dcmread
 
-import warnings
-
 from rt_utils.utils import SOPClassUID
+
 from . import ds_helper, image_helper
 from .rtstruct import RTStruct
 
@@ -23,6 +24,17 @@ class RTStructBuilder:
         series_data = image_helper.load_sorted_image_series(dicom_series_path)
         ds = ds_helper.create_rtstruct_dataset(series_data)
         return RTStruct(series_data, ds)
+    
+    @staticmethod
+    def create_new_from_memory(dicom_datasets: List[Dataset]) -> RTStruct:
+        """
+         Method to generate a new rt struct from a DICOM series in memory already loaded by pydicom
+        """
+        # dicom_datasets are sorted by InstanceNumber
+        dicom_datasets.sort(key=lambda x: x.InstanceNumber if hasattr(x, 'InstanceNumber') else 0)
+
+        ds = ds_helper.create_rtstruct_dataset(dicom_datasets)
+        return RTStruct(dicom_datasets, ds)
 
     @staticmethod
     def create_from(dicom_series_path: str, rt_struct_path: str, warn_only: bool = False) -> RTStruct:


### PR DESCRIPTION
I have implemented significant enhancements to the RTUtils library, which originally required file path dependencies for generating and manipulating RTStructs (Radiotherapy Structures). My contribution specifically addresses the limitation of needing file paths, which was not feasible for API-driven environments where direct file system access is restricted or undesirable.

#### Key Enhancements:

1. **Memory-Based RTStruct Creation**:
   - Developed a new method, `create_new_from_memory`, which allows RTStructs to be created directly from DICOM datasets already loaded into memory using PyDicom. This enhancement is crucial for deploying the library in server environments where DICOM files are received as streams or over network protocols without storing them on disk.

2. **In-Memory RTStruct Saving**:
   - Added the `save_to_memory` function to the RTStruct class. This method facilitates the generation of RTStructs without needing to write to the filesystem. It saves the RTStruct to a BytesIO stream, which can then be used directly within applications or sent over networks, thus enhancing the usability of the library in distributed systems and cloud applications.

3. **API Compatibility**:
   - Adjusted the library to be more compatible with web and cloud-based applications by enabling DICOM processing and RTStruct manipulation entirely in memory, aligning with modern microservices architectures and RESTful API practices.

#### Use Case in API:
Implemented the enhancements in a REST API setting, where DICOM files are retrieved and processed on-the-fly. The updated library handles DICOM files received from HTTP requests, processes them to generate RTStructs, and optionally uploads them to DICOM servers without intermediate disk I/O, demonstrating the library's enhanced functionality in a live server environment.

It would be great to have a feature like this! Thanks!