### PR TITLE
Update roi_number calculation in RTStruct

### DIFF
--- a/rt_utils/rtstruct.py
+++ b/rt_utils/rtstruct.py
@@ -78,7 +78,8 @@ class RTStruct:
         """
         # TODO: test if name already exists
         self.validate_mask(mask)
-        roi_number = len(self.ds.StructureSetROISequence) + 1
+        #roi_number = len(self.ds.StructureSetROISequence) + 1
+        roi_number = self.ds.ROINumberSequence[-1] + 1
         roi_data = ROIData(
             mask,
             color,


### PR DESCRIPTION
This pull request is the fix for the issue I opened. It fixes the situation where the user removes a ROI using an external RTStruct viewer and the ROI numbers stay the same. This causes the assigned ROI number to be the same as the last ROI number.