### PR TITLE
Prepare release 1.3.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.md
+include RELEASING.md
+include requirements.txt

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,24 @@
+# Releasing RT-Utils
+
+The package version has a single source of truth in
+`rt_utils/_version.py`. `setup.py` reads that value without importing the
+package.
+
+## Release checklist
+
+1. Update `rt_utils/_version.py` and merge the change into `main`.
+2. Run the complete test suite.
+3. Build and validate both distributions:
+
+   ```bash
+   python -m build
+   python -m twine check dist/*
+   ```
+
+4. Install the wheel in a clean environment and confirm `rt_utils.__version__`.
+5. Upload only the artifacts for the intended version to PyPI.
+6. Tag the exact published commit as `v<version>`.
+7. Create the matching GitHub release from that tag.
+
+PyPI distributions cannot be replaced. Never tag or upload from an uncommitted
+or untested working tree.

--- a/rt_utils/__init__.py
+++ b/rt_utils/__init__.py
@@ -1,3 +1,6 @@
+from ._version import __version__
 from .rtstruct import RTStruct
 from .rtstruct_builder import RTStructBuilder
 from .rtstruct_merger import RTStructMerger
+
+__all__ = ["RTStruct", "RTStructBuilder", "RTStructMerger", "__version__"]

--- a/rt_utils/_version.py
+++ b/rt_utils/_version.py
@@ -1,0 +1,3 @@
+"""RT-Utils package version."""
+
+__version__ = "1.3.1"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
+from pathlib import Path
+
 import setuptools
 
-VERSION = "1.2.6"
+version_namespace = {}
+exec(Path("rt_utils/_version.py").read_text(encoding="utf-8"), version_namespace)
+VERSION = version_namespace["__version__"]
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 with open("requirements.txt") as f:
@@ -14,16 +18,14 @@ setuptools.setup(
     description="A small library for handling masks and RT-Structs",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/qurit/rtutils",
-    package_dir={'':"rt_utils"},
-    packages=setuptools.find_packages("rt_utils", exclude="tests"),
+    url="https://github.com/qurit/rt-utils",
+    packages=setuptools.find_packages(exclude=["tests"]),
     keywords=["RTStruct", "Dicom", "Pydicom"],
     classifiers=[
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -39,6 +41,6 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=required,
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,14 @@
 import numpy as np
 import pytest
 
+from rt_utils import __version__
 from rt_utils.image_helper import mask_to_edge_polygons
 from rt_utils.utils import COLOR_PALETTE
 from tests.test_rtstruct_builder import get_empty_mask
+
+
+def test_package_version():
+    assert __version__ == "1.3.1"
 
 
 def test_single_voxel_edge_polygon():


### PR DESCRIPTION
## Summary

Prepares RT-Utils 1.3.1 for publication to PyPI after the voxel-edge contour
feature was merged.

## Version and metadata consistency

- Adds `rt_utils/_version.py` as the package version source of truth.
- Exposes `rt_utils.__version__`.
- Updates package metadata to 1.3.1.
- Corrects the repository homepage URL.
- Aligns declared Python support with the tested CI floor by requiring Python
  3.8+.

## Packaging fixes

Release validation exposed two existing source-distribution defects:

- The previous `package_dir`/`find_packages` combination omitted package source
  files from the sdist.
- `requirements.txt`, which `setup.py` reads, was omitted from the sdist.

This PR fixes package discovery and adds `MANIFEST.in` so both the sdist and
wheel can be built from the generated sdist.

## Release process

Adds `RELEASING.md` with an explicit test, build, upload, tag, and GitHub-release
sequence to prevent GitHub/PyPI version drift.

## Validation

- Full test suite: 46 passed.
- `python -m build`: passed for sdist and wheel.
- `python -m twine check`: passed for both artifacts.
- Verified artifact metadata: name `rt-utils`, version `1.3.1`, Python `>=3.8`.
- Verified package source and build inputs exist in the sdist.
- Installed the built wheel and verified both `rt_utils.__version__` and
  `importlib.metadata.version("rt-utils")` equal `1.3.1`.
